### PR TITLE
Generalising the type signature of `map`.

### DIFF
--- a/src/AllDict.elm
+++ b/src/AllDict.elm
@@ -489,11 +489,11 @@ redden t =
 
 
 {-| Apply a function to all values in a dictionary. -}
-map : (k -> a -> a) -> AllDict k a comparable -> AllDict k a comparable
+map : (k -> a -> b) -> AllDict k a comparable -> AllDict k b comparable
 map f dict =
     case dict of
-      RBEmpty_elm_builtin _ ord ->
-          dict
+      RBEmpty_elm_builtin clr ord ->
+          RBEmpty_elm_builtin clr ord
 
       RBNode_elm_builtin clr key value left right ->
           RBNode_elm_builtin clr key (f key value) (map f left) (map f right)

--- a/src/EveryDict.elm
+++ b/src/EveryDict.elm
@@ -443,11 +443,11 @@ redden t =
 
 {-| Apply a function to all values in a dictionary.
 -}
-map : (k -> a -> a) -> EveryDict k a -> EveryDict k a
+map : (k -> a -> b) -> EveryDict k a -> EveryDict k b
 map f dict =
     case dict of
-      RBEmpty_elm_builtin _ ->
-          dict
+      RBEmpty_elm_builtin clr ->
+          RBEmpty_elm_builtin clr
 
       RBNode_elm_builtin clr key value left right ->
           RBNode_elm_builtin clr key (f key value) (map f left) (map f right)


### PR DESCRIPTION
The signature for `map` is `(k -> a -> a) ...`, instead of the core's `(k -> a -> b) ...`.

I've just bumped into this incompatibility, and it's a really easy fix, so here's a PR I hope you'll like. :-)

Thanks for the library BTW - I really hope this gets adopted by elm-core. :-D
